### PR TITLE
feat: update SQLC queries for new table structure

### DIFF
--- a/.kiro/specs/frequency-based-gauge-filtering/tasks.md
+++ b/.kiro/specs/frequency-based-gauge-filtering/tasks.md
@@ -30,7 +30,7 @@
   - Create necessary indexes for performance
   - _Requirements: 2.1, 3.2_
 
-- [ ] 3. Update SQLC queries for new table structure
+- [x] 3. Update SQLC queries for new table structure
   - Create queries for gauge_templates CRUD operations
   - Create queries for gauge_instances CRUD operations
   - Update existing gauge queries to work with new schema

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -12,32 +12,37 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestQueries_CreateAndGetGauge(t *testing.T) {
+func TestQueries_CreateAndGetGaugeTemplate(t *testing.T) {
 	q := testutil.NewTestDB(t)
 	ctx := context.Background()
 
-	t.Run("create and get gauge", func(t *testing.T) {
-		params := db.CreateGaugeParams{
+	t.Run("create and get gauge template", func(t *testing.T) {
+		params := db.CreateGaugeTemplateParams{
 			Name:        "Test Gauge",
 			Description: sql.NullString{String: "Test Description", Valid: true},
 			Target:      100,
 			Unit:        "units",
 			Icon:        "star",
+			Frequency:   "weekly",
+			Direction:   "under",
+			Active:      true,
 		}
 
-		// Create gauge
-		gauge, err := q.CreateGauge(ctx, params)
+		// Create gauge template
+		template, err := q.CreateGaugeTemplate(ctx, params)
 		assert.NoError(t, err)
-		assert.Equal(t, params.Name, gauge.Name)
-		assert.Equal(t, params.Description, gauge.Description)
-		assert.Equal(t, params.Target, gauge.Target)
-		assert.Equal(t, params.Unit, gauge.Unit)
-		assert.Equal(t, params.Icon, gauge.Icon)
+		assert.Equal(t, params.Name, template.Name)
+		assert.Equal(t, params.Description, template.Description)
+		assert.Equal(t, params.Target, template.Target)
+		assert.Equal(t, params.Unit, template.Unit)
+		assert.Equal(t, params.Icon, template.Icon)
+		assert.Equal(t, params.Frequency, template.Frequency)
+		assert.Equal(t, params.Active, template.Active)
 
-		// Get gauge
-		retrieved, err := q.GetGauge(ctx, gauge.ID)
+		// Get gauge template
+		retrieved, err := q.GetGaugeTemplate(ctx, template.ID)
 		assert.NoError(t, err)
-		assert.Equal(t, gauge, retrieved)
+		assert.Equal(t, template, retrieved)
 	})
 }
 
@@ -46,33 +51,33 @@ func TestQueries_GaugeValues(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("create and get gauge values", func(t *testing.T) {
-		// Create gauge
-		gauge := testutil.CreateTestGauge(t, q)
+		// Create gauge template and instance
+		template := testutil.CreateTestGaugeTemplate(t, q)
+		instance := testutil.CreateTestGaugeInstance(t, q, template.ID, time.Now().UTC())
 
-		// Create values
+		// Create values (all in the same month to test averaging)
 		now := time.Now().UTC()
 		values := []struct {
 			value float64
 			date  time.Time
 		}{
-			{50, now.AddDate(0, -2, 0)},
-			{75, now.AddDate(0, -1, 0)},
-			{100, now},
+			{50, now.AddDate(0, 0, -2)},  // 2 days ago
+			{75, now.AddDate(0, 0, -1)},  // 1 day ago
+			{100, now},                   // today
 		}
 
 		for _, v := range values {
-			err := testutil.CreateTestGaugeValue(t, q, gauge.ID, v.value, v.date)
+			err := testutil.CreateTestGaugeValue(t, q, instance.ID, v.value, v.date)
 			assert.NoError(t, err)
 		}
 
-		// Get history
-		history, err := q.GetGaugeHistory(ctx, gauge.ID)
+		// Get history (should be grouped by month and averaged)
+		history, err := q.GetGaugeHistory(ctx, instance.ID)
 		assert.NoError(t, err)
-		assert.Len(t, history, 3)
+		assert.Len(t, history, 1) // All values are in the same month
 
-		// Values should be ordered by date DESC (newest first)
-		assert.Equal(t, 100.0, history[0].AverageValue)
-		assert.Equal(t, 75.0, history[1].AverageValue)
-		assert.Equal(t, 50.0, history[2].AverageValue)
+		// Average of 50, 75, 100 should be 75
+		expectedAverage := (50.0 + 75.0 + 100.0) / 3.0
+		assert.Equal(t, expectedAverage, history[0].AverageValue)
 	})
 }

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pressly/goose/v3"
 )
 
-//go:embed ../../migrations/*.sql
+//go:embed migrations/*.sql
 var embedMigrations embed.FS
 
 // RunMigrations runs all pending Goose migrations

--- a/internal/db/migrations/00001_initial_schema.sql
+++ b/internal/db/migrations/00001_initial_schema.sql
@@ -19,10 +19,17 @@ CREATE TABLE gauge_values (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     gauge_id INTEGER NOT NULL,
     value REAL NOT NULL,
-    week INTEGER NOT NULL,
-    year INTEGER NOT NULL,
+    week INTEGER NOT NULL CHECK (week >= 1 AND week <= 53),
+    year INTEGER NOT NULL CHECK (year >= 1900 AND year <= 2100),
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (gauge_id) REFERENCES gauges(id) ON DELETE CASCADE
+    FOREIGN KEY (gauge_id) REFERENCES gauges(id) ON DELETE CASCADE,
+    -- Ensure week 53 only exists in years that actually have 53 weeks
+    CHECK (week <= 52 OR (week = 53 AND (
+        -- Years with 53 weeks: years starting on Thursday or leap years starting on Wednesday
+        (year % 4 = 0 AND year % 100 != 0) OR (year % 400 = 0) OR
+        (strftime('%w', year || '-01-01') = '4') OR
+        ((year % 4 = 0 AND year % 100 != 0 OR year % 400 = 0) AND strftime('%w', year || '-01-01') = '3')
+    )))
 );
 
 -- Create indexes

--- a/internal/db/migrations/00001_initial_schema.sql
+++ b/internal/db/migrations/00001_initial_schema.sql
@@ -1,0 +1,36 @@
+-- +goose Up
+-- Create gauges table
+CREATE TABLE gauges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    description TEXT,
+    target REAL NOT NULL,
+    value REAL DEFAULT 0,
+    unit TEXT NOT NULL,
+    icon TEXT DEFAULT 'chart-bar',
+    frequency TEXT,
+    direction TEXT DEFAULT 'under',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create gauge_values table
+CREATE TABLE gauge_values (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    gauge_id INTEGER NOT NULL,
+    value REAL NOT NULL,
+    week INTEGER NOT NULL,
+    year INTEGER NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (gauge_id) REFERENCES gauges(id) ON DELETE CASCADE
+);
+
+-- Create indexes
+CREATE INDEX idx_gauge_values_gauge_id ON gauge_values(gauge_id);
+CREATE INDEX idx_gauge_values_week_year ON gauge_values(week, year);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_gauge_values_week_year;
+DROP INDEX IF EXISTS idx_gauge_values_gauge_id;
+DROP TABLE IF EXISTS gauge_values;
+DROP TABLE IF EXISTS gauges;

--- a/internal/db/migrations/00002_create_gauge_templates_instances.sql
+++ b/internal/db/migrations/00002_create_gauge_templates_instances.sql
@@ -43,6 +43,7 @@ CREATE INDEX idx_gauge_templates_active ON gauge_templates(active);
 CREATE INDEX idx_gauge_templates_frequency ON gauge_templates(frequency);
 CREATE INDEX idx_gauge_instances_template ON gauge_instances(template_id);
 CREATE INDEX idx_gauge_instances_period ON gauge_instances(period_start);
+CREATE UNIQUE INDEX idx_gauge_instances_template_period ON gauge_instances(template_id, period_start);
 CREATE INDEX idx_gauge_values_gauge_id ON gauge_values(gauge_id);
 CREATE INDEX idx_gauge_values_date ON gauge_values(date);
 

--- a/internal/db/migrations/00002_create_gauge_templates_instances.sql
+++ b/internal/db/migrations/00002_create_gauge_templates_instances.sql
@@ -1,0 +1,76 @@
+-- +goose Up
+-- Create gauge_templates table
+CREATE TABLE gauge_templates (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    description TEXT,
+    target REAL NOT NULL,
+    unit TEXT NOT NULL,
+    icon TEXT NOT NULL DEFAULT 'chart-bar',
+    frequency TEXT NOT NULL CHECK (frequency IN ('weekly', 'bi-weekly', 'monthly')),
+    direction TEXT NOT NULL DEFAULT 'under' CHECK (direction IN ('under', 'over')),
+    active BOOLEAN DEFAULT false,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create gauge_instances table
+CREATE TABLE gauge_instances (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    template_id INTEGER NOT NULL,
+    period_start DATE NOT NULL,
+    value REAL NOT NULL DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (template_id) REFERENCES gauge_templates(id) ON DELETE CASCADE
+);
+
+-- Drop the old gauge_values table
+DROP TABLE IF EXISTS gauge_values;
+
+-- Create new gauge_values table that references gauge_instances
+CREATE TABLE gauge_values (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    gauge_id INTEGER NOT NULL,
+    value REAL NOT NULL,
+    date DATETIME NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (gauge_id) REFERENCES gauge_instances(id) ON DELETE CASCADE
+);
+
+-- Create indexes for performance
+CREATE INDEX idx_gauge_templates_active ON gauge_templates(active);
+CREATE INDEX idx_gauge_templates_frequency ON gauge_templates(frequency);
+CREATE INDEX idx_gauge_instances_template ON gauge_instances(template_id);
+CREATE INDEX idx_gauge_instances_period ON gauge_instances(period_start);
+CREATE INDEX idx_gauge_values_gauge_id ON gauge_values(gauge_id);
+CREATE INDEX idx_gauge_values_date ON gauge_values(date);
+
+-- +goose Down
+-- Drop indexes
+DROP INDEX IF EXISTS idx_gauge_values_date;
+DROP INDEX IF EXISTS idx_gauge_values_gauge_id;
+DROP INDEX IF EXISTS idx_gauge_instances_period;
+DROP INDEX IF EXISTS idx_gauge_instances_template;
+DROP INDEX IF EXISTS idx_gauge_templates_frequency;
+DROP INDEX IF EXISTS idx_gauge_templates_active;
+
+-- Drop tables
+DROP TABLE IF EXISTS gauge_values;
+DROP TABLE IF EXISTS gauge_instances;
+DROP TABLE IF EXISTS gauge_templates;
+
+-- Recreate original gauge_values table
+CREATE TABLE gauge_values (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    gauge_id INTEGER NOT NULL,
+    value REAL NOT NULL,
+    week INTEGER NOT NULL,
+    year INTEGER NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (gauge_id) REFERENCES gauges(id) ON DELETE CASCADE
+);
+
+-- Recreate original indexes
+CREATE INDEX idx_gauge_values_gauge_id ON gauge_values(gauge_id);
+CREATE INDEX idx_gauge_values_week_year ON gauge_values(week, year);

--- a/internal/db/mock_queries.go
+++ b/internal/db/mock_queries.go
@@ -4,34 +4,105 @@ import "context"
 
 // MockQueries is a mock implementation of the Querier interface for testing
 type MockQueries struct {
-	CreateGaugeFn       func(ctx context.Context, params CreateGaugeParams) (Gauge, error)
-	UpdateGaugeFn       func(ctx context.Context, params UpdateGaugeParams) error
-	DeleteGaugeFn       func(ctx context.Context, id int64) error
-	GetGaugeFn         func(ctx context.Context, id int64) (Gauge, error)
-	ListGaugesFn     func(ctx context.Context) ([]Gauge, error)
-	UpdateGaugeValueFn func(ctx context.Context, params UpdateGaugeValueParams) error
+	// Gauge Template methods
+	CreateGaugeTemplateFn       func(ctx context.Context, params CreateGaugeTemplateParams) (GaugeTemplate, error)
+	UpdateGaugeTemplateFn       func(ctx context.Context, params UpdateGaugeTemplateParams) error
+	DeleteGaugeTemplateFn       func(ctx context.Context, id int64) error
+	GetGaugeTemplateFn         func(ctx context.Context, id int64) (GaugeTemplate, error)
+	ListGaugeTemplatesFn       func(ctx context.Context) ([]GaugeTemplate, error)
+	ListActiveGaugeTemplatesFn func(ctx context.Context) ([]GaugeTemplate, error)
+	
+	// Gauge Instance methods
+	CreateGaugeInstanceFn       func(ctx context.Context, params CreateGaugeInstanceParams) (GaugeInstance, error)
+	UpdateGaugeInstanceValueFn  func(ctx context.Context, params UpdateGaugeInstanceValueParams) error
+	DeleteGaugeInstanceFn       func(ctx context.Context, id int64) error
+	GetGaugeInstanceFn         func(ctx context.Context, id int64) (GaugeInstance, error)
+	ListGaugeInstancesFn       func(ctx context.Context) ([]GaugeInstance, error)
+	ListGaugeInstancesByTemplateFn func(ctx context.Context, templateID int64) ([]GaugeInstance, error)
+	InstanceExistsForPeriodFn  func(ctx context.Context, params InstanceExistsForPeriodParams) (int64, error)
+	
+	// Dashboard methods
+	ListCurrentPeriodGaugeInstancesFn func(ctx context.Context, params ListCurrentPeriodGaugeInstancesParams) ([]ListCurrentPeriodGaugeInstancesRow, error)
+	
+	// Gauge Value methods
+	CreateGaugeValueFn func(ctx context.Context, params CreateGaugeValueParams) error
+	GetCurrentValueFn  func(ctx context.Context, gaugeID int64) (float64, error)
+	GetGaugeValuesFn   func(ctx context.Context, gaugeID int64) ([]GaugeValue, error)
+	GetGaugeHistoryFn  func(ctx context.Context, gaugeID int64) ([]GetGaugeHistoryRow, error)
 }
 
-func (m *MockQueries) CreateGauge(ctx context.Context, params CreateGaugeParams) (Gauge, error) {
-	return m.CreateGaugeFn(ctx, params)
+// Gauge Template methods
+func (m *MockQueries) CreateGaugeTemplate(ctx context.Context, params CreateGaugeTemplateParams) (GaugeTemplate, error) {
+	return m.CreateGaugeTemplateFn(ctx, params)
 }
 
-func (m *MockQueries) UpdateGauge(ctx context.Context, params UpdateGaugeParams) error {
-	return m.UpdateGaugeFn(ctx, params)
+func (m *MockQueries) UpdateGaugeTemplate(ctx context.Context, params UpdateGaugeTemplateParams) error {
+	return m.UpdateGaugeTemplateFn(ctx, params)
 }
 
-func (m *MockQueries) DeleteGauge(ctx context.Context, id int64) error {
-	return m.DeleteGaugeFn(ctx, id)
+func (m *MockQueries) DeleteGaugeTemplate(ctx context.Context, id int64) error {
+	return m.DeleteGaugeTemplateFn(ctx, id)
 }
 
-func (m *MockQueries) GetGauge(ctx context.Context, id int64) (Gauge, error) {
-	return m.GetGaugeFn(ctx, id)
+func (m *MockQueries) GetGaugeTemplate(ctx context.Context, id int64) (GaugeTemplate, error) {
+	return m.GetGaugeTemplateFn(ctx, id)
 }
 
-func (m *MockQueries) ListGauges(ctx context.Context) ([]Gauge, error) {
-	return m.ListGaugesFn(ctx)
+func (m *MockQueries) ListGaugeTemplates(ctx context.Context) ([]GaugeTemplate, error) {
+	return m.ListGaugeTemplatesFn(ctx)
 }
 
-func (m *MockQueries) UpdateGaugeValue(ctx context.Context, params UpdateGaugeValueParams) error {
-	return m.UpdateGaugeValueFn(ctx, params)
+func (m *MockQueries) ListActiveGaugeTemplates(ctx context.Context) ([]GaugeTemplate, error) {
+	return m.ListActiveGaugeTemplatesFn(ctx)
+}
+
+// Gauge Instance methods
+func (m *MockQueries) CreateGaugeInstance(ctx context.Context, params CreateGaugeInstanceParams) (GaugeInstance, error) {
+	return m.CreateGaugeInstanceFn(ctx, params)
+}
+
+func (m *MockQueries) UpdateGaugeInstanceValue(ctx context.Context, params UpdateGaugeInstanceValueParams) error {
+	return m.UpdateGaugeInstanceValueFn(ctx, params)
+}
+
+func (m *MockQueries) DeleteGaugeInstance(ctx context.Context, id int64) error {
+	return m.DeleteGaugeInstanceFn(ctx, id)
+}
+
+func (m *MockQueries) GetGaugeInstance(ctx context.Context, id int64) (GaugeInstance, error) {
+	return m.GetGaugeInstanceFn(ctx, id)
+}
+
+func (m *MockQueries) ListGaugeInstances(ctx context.Context) ([]GaugeInstance, error) {
+	return m.ListGaugeInstancesFn(ctx)
+}
+
+func (m *MockQueries) ListGaugeInstancesByTemplate(ctx context.Context, templateID int64) ([]GaugeInstance, error) {
+	return m.ListGaugeInstancesByTemplateFn(ctx, templateID)
+}
+
+func (m *MockQueries) InstanceExistsForPeriod(ctx context.Context, params InstanceExistsForPeriodParams) (int64, error) {
+	return m.InstanceExistsForPeriodFn(ctx, params)
+}
+
+// Dashboard methods
+func (m *MockQueries) ListCurrentPeriodGaugeInstances(ctx context.Context, params ListCurrentPeriodGaugeInstancesParams) ([]ListCurrentPeriodGaugeInstancesRow, error) {
+	return m.ListCurrentPeriodGaugeInstancesFn(ctx, params)
+}
+
+// Gauge Value methods
+func (m *MockQueries) CreateGaugeValue(ctx context.Context, params CreateGaugeValueParams) error {
+	return m.CreateGaugeValueFn(ctx, params)
+}
+
+func (m *MockQueries) GetCurrentValue(ctx context.Context, gaugeID int64) (float64, error) {
+	return m.GetCurrentValueFn(ctx, gaugeID)
+}
+
+func (m *MockQueries) GetGaugeValues(ctx context.Context, gaugeID int64) ([]GaugeValue, error) {
+	return m.GetGaugeValuesFn(ctx, gaugeID)
+}
+
+func (m *MockQueries) GetGaugeHistory(ctx context.Context, gaugeID int64) ([]GetGaugeHistoryRow, error) {
+	return m.GetGaugeHistoryFn(ctx, gaugeID)
 }

--- a/internal/db/mock_queries.go
+++ b/internal/db/mock_queries.go
@@ -33,76 +33,130 @@ type MockQueries struct {
 
 // Gauge Template methods
 func (m *MockQueries) CreateGaugeTemplate(ctx context.Context, params CreateGaugeTemplateParams) (GaugeTemplate, error) {
+	if m.CreateGaugeTemplateFn == nil {
+		return GaugeTemplate{}, nil
+	}
 	return m.CreateGaugeTemplateFn(ctx, params)
 }
 
 func (m *MockQueries) UpdateGaugeTemplate(ctx context.Context, params UpdateGaugeTemplateParams) error {
+	if m.UpdateGaugeTemplateFn == nil {
+		return nil
+	}
 	return m.UpdateGaugeTemplateFn(ctx, params)
 }
 
 func (m *MockQueries) DeleteGaugeTemplate(ctx context.Context, id int64) error {
+	if m.DeleteGaugeTemplateFn == nil {
+		return nil
+	}
 	return m.DeleteGaugeTemplateFn(ctx, id)
 }
 
 func (m *MockQueries) GetGaugeTemplate(ctx context.Context, id int64) (GaugeTemplate, error) {
+	if m.GetGaugeTemplateFn == nil {
+		return GaugeTemplate{}, nil
+	}
 	return m.GetGaugeTemplateFn(ctx, id)
 }
 
 func (m *MockQueries) ListGaugeTemplates(ctx context.Context) ([]GaugeTemplate, error) {
+	if m.ListGaugeTemplatesFn == nil {
+		return []GaugeTemplate{}, nil
+	}
 	return m.ListGaugeTemplatesFn(ctx)
 }
 
 func (m *MockQueries) ListActiveGaugeTemplates(ctx context.Context) ([]GaugeTemplate, error) {
+	if m.ListActiveGaugeTemplatesFn == nil {
+		return []GaugeTemplate{}, nil
+	}
 	return m.ListActiveGaugeTemplatesFn(ctx)
 }
 
 // Gauge Instance methods
 func (m *MockQueries) CreateGaugeInstance(ctx context.Context, params CreateGaugeInstanceParams) (GaugeInstance, error) {
+	if m.CreateGaugeInstanceFn == nil {
+		return GaugeInstance{}, nil
+	}
 	return m.CreateGaugeInstanceFn(ctx, params)
 }
 
 func (m *MockQueries) UpdateGaugeInstanceValue(ctx context.Context, params UpdateGaugeInstanceValueParams) error {
+	if m.UpdateGaugeInstanceValueFn == nil {
+		return nil
+	}
 	return m.UpdateGaugeInstanceValueFn(ctx, params)
 }
 
 func (m *MockQueries) DeleteGaugeInstance(ctx context.Context, id int64) error {
+	if m.DeleteGaugeInstanceFn == nil {
+		return nil
+	}
 	return m.DeleteGaugeInstanceFn(ctx, id)
 }
 
 func (m *MockQueries) GetGaugeInstance(ctx context.Context, id int64) (GaugeInstance, error) {
+	if m.GetGaugeInstanceFn == nil {
+		return GaugeInstance{}, nil
+	}
 	return m.GetGaugeInstanceFn(ctx, id)
 }
 
 func (m *MockQueries) ListGaugeInstances(ctx context.Context) ([]GaugeInstance, error) {
+	if m.ListGaugeInstancesFn == nil {
+		return []GaugeInstance{}, nil
+	}
 	return m.ListGaugeInstancesFn(ctx)
 }
 
 func (m *MockQueries) ListGaugeInstancesByTemplate(ctx context.Context, templateID int64) ([]GaugeInstance, error) {
+	if m.ListGaugeInstancesByTemplateFn == nil {
+		return []GaugeInstance{}, nil
+	}
 	return m.ListGaugeInstancesByTemplateFn(ctx, templateID)
 }
 
 func (m *MockQueries) InstanceExistsForPeriod(ctx context.Context, params InstanceExistsForPeriodParams) (int64, error) {
+	if m.InstanceExistsForPeriodFn == nil {
+		return 0, nil
+	}
 	return m.InstanceExistsForPeriodFn(ctx, params)
 }
 
 // Dashboard methods
 func (m *MockQueries) ListCurrentPeriodGaugeInstances(ctx context.Context, params ListCurrentPeriodGaugeInstancesParams) ([]ListCurrentPeriodGaugeInstancesRow, error) {
+	if m.ListCurrentPeriodGaugeInstancesFn == nil {
+		return []ListCurrentPeriodGaugeInstancesRow{}, nil
+	}
 	return m.ListCurrentPeriodGaugeInstancesFn(ctx, params)
 }
 
 // Gauge Value methods
 func (m *MockQueries) CreateGaugeValue(ctx context.Context, params CreateGaugeValueParams) error {
+	if m.CreateGaugeValueFn == nil {
+		return nil
+	}
 	return m.CreateGaugeValueFn(ctx, params)
 }
 
 func (m *MockQueries) GetCurrentValue(ctx context.Context, gaugeID int64) (float64, error) {
+	if m.GetCurrentValueFn == nil {
+		return 0.0, nil
+	}
 	return m.GetCurrentValueFn(ctx, gaugeID)
 }
 
 func (m *MockQueries) GetGaugeValues(ctx context.Context, gaugeID int64) ([]GaugeValue, error) {
+	if m.GetGaugeValuesFn == nil {
+		return []GaugeValue{}, nil
+	}
 	return m.GetGaugeValuesFn(ctx, gaugeID)
 }
 
 func (m *MockQueries) GetGaugeHistory(ctx context.Context, gaugeID int64) ([]GetGaugeHistoryRow, error) {
+	if m.GetGaugeHistoryFn == nil {
+		return []GetGaugeHistoryRow{}, nil
+	}
 	return m.GetGaugeHistoryFn(ctx, gaugeID)
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -9,16 +9,25 @@ import (
 	"time"
 )
 
-type Gauge struct {
+type GaugeInstance struct {
+	ID          int64        `json:"id"`
+	TemplateID  int64        `json:"template_id"`
+	PeriodStart time.Time    `json:"period_start"`
+	Value       float64      `json:"value"`
+	CreatedAt   sql.NullTime `json:"created_at"`
+	UpdatedAt   sql.NullTime `json:"updated_at"`
+}
+
+type GaugeTemplate struct {
 	ID          int64          `json:"id"`
 	Name        string         `json:"name"`
 	Description sql.NullString `json:"description"`
 	Target      float64        `json:"target"`
-	Value       float64        `json:"value"`
 	Unit        string         `json:"unit"`
 	Icon        string         `json:"icon"`
 	Frequency   string         `json:"frequency"`
 	Direction   string         `json:"direction"`
+	Active      bool           `json:"active"`
 	CreatedAt   sql.NullTime   `json:"created_at"`
 	UpdatedAt   sql.NullTime   `json:"updated_at"`
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -9,16 +9,27 @@ import (
 )
 
 type Querier interface {
-	CreateGauge(ctx context.Context, arg CreateGaugeParams) (Gauge, error)
+	CreateGaugeInstance(ctx context.Context, arg CreateGaugeInstanceParams) (GaugeInstance, error)
+	CreateGaugeTemplate(ctx context.Context, arg CreateGaugeTemplateParams) (GaugeTemplate, error)
 	CreateGaugeValue(ctx context.Context, arg CreateGaugeValueParams) error
-	DeleteGauge(ctx context.Context, id int64) error
+	DeleteGaugeInstance(ctx context.Context, id int64) error
+	DeleteGaugeTemplate(ctx context.Context, id int64) error
 	GetCurrentValue(ctx context.Context, gaugeID int64) (float64, error)
-	GetGauge(ctx context.Context, id int64) (Gauge, error)
 	GetGaugeHistory(ctx context.Context, gaugeID int64) ([]GetGaugeHistoryRow, error)
+	// Gauge Instances CRUD Operations
+	GetGaugeInstance(ctx context.Context, id int64) (GaugeInstance, error)
+	// Gauge Templates CRUD Operations
+	GetGaugeTemplate(ctx context.Context, id int64) (GaugeTemplate, error)
 	GetGaugeValues(ctx context.Context, gaugeID int64) ([]GaugeValue, error)
-	ListGauges(ctx context.Context) ([]Gauge, error)
-	UpdateGauge(ctx context.Context, arg UpdateGaugeParams) error
-	UpdateGaugeValue(ctx context.Context, arg UpdateGaugeValueParams) error
+	InstanceExistsForPeriod(ctx context.Context, arg InstanceExistsForPeriodParams) (int64, error)
+	ListActiveGaugeTemplates(ctx context.Context) ([]GaugeTemplate, error)
+	// Dashboard and Current Period Queries
+	ListCurrentPeriodGaugeInstances(ctx context.Context, arg ListCurrentPeriodGaugeInstancesParams) ([]ListCurrentPeriodGaugeInstancesRow, error)
+	ListGaugeInstances(ctx context.Context) ([]GaugeInstance, error)
+	ListGaugeInstancesByTemplate(ctx context.Context, templateID int64) ([]GaugeInstance, error)
+	ListGaugeTemplates(ctx context.Context) ([]GaugeTemplate, error)
+	UpdateGaugeInstanceValue(ctx context.Context, arg UpdateGaugeInstanceValueParams) error
+	UpdateGaugeTemplate(ctx context.Context, arg UpdateGaugeTemplateParams) error
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -1,16 +1,20 @@
--- name: GetGauge :one
-SELECT * FROM gauges WHERE id = ? LIMIT 1;
+-- Gauge Templates CRUD Operations
+-- name: GetGaugeTemplate :one
+SELECT * FROM gauge_templates WHERE id = ? LIMIT 1;
 
--- name: ListGauges :many
-SELECT * FROM gauges ORDER BY name;
+-- name: ListGaugeTemplates :many
+SELECT * FROM gauge_templates ORDER BY name;
 
--- name: CreateGauge :one
-INSERT INTO gauges (name, description, target, value, unit, icon, frequency, direction)
-VALUES (?, ?, ?, 0, ?, ?, ?, ?)
+-- name: ListActiveGaugeTemplates :many
+SELECT * FROM gauge_templates WHERE active = true ORDER BY name;
+
+-- name: CreateGaugeTemplate :one
+INSERT INTO gauge_templates (name, description, target, unit, icon, frequency, direction, active)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
--- name: UpdateGauge :exec
-UPDATE gauges
+-- name: UpdateGaugeTemplate :exec
+UPDATE gauge_templates
 SET name = ?,
     description = ?,
     target = ?,
@@ -18,17 +22,51 @@ SET name = ?,
     icon = ?,
     frequency = ?,
     direction = ?,
+    active = ?,
     updated_at = CURRENT_TIMESTAMP
 WHERE id = ?;
 
--- name: UpdateGaugeValue :exec
-UPDATE gauges
+-- name: DeleteGaugeTemplate :exec
+DELETE FROM gauge_templates WHERE id = ?;
+
+-- Gauge Instances CRUD Operations
+-- name: GetGaugeInstance :one
+SELECT * FROM gauge_instances WHERE id = ? LIMIT 1;
+
+-- name: ListGaugeInstances :many
+SELECT * FROM gauge_instances ORDER BY period_start DESC;
+
+-- name: ListGaugeInstancesByTemplate :many
+SELECT * FROM gauge_instances WHERE template_id = ? ORDER BY period_start DESC;
+
+-- name: CreateGaugeInstance :one
+INSERT INTO gauge_instances (template_id, period_start, value)
+VALUES (?, ?, 0)
+RETURNING *;
+
+-- name: UpdateGaugeInstanceValue :exec
+UPDATE gauge_instances
 SET value = ?,
     updated_at = CURRENT_TIMESTAMP
 WHERE id = ?;
 
--- name: DeleteGauge :exec
-DELETE FROM gauges WHERE id = ?;
+-- name: DeleteGaugeInstance :exec
+DELETE FROM gauge_instances WHERE id = ?;
+
+-- name: InstanceExistsForPeriod :one
+SELECT COUNT(*) FROM gauge_instances 
+WHERE template_id = ? AND period_start = ?;
+
+-- Dashboard and Current Period Queries
+-- name: ListCurrentPeriodGaugeInstances :many
+SELECT gi.*, gt.name, gt.description, gt.target, gt.unit, gt.icon, gt.frequency, gt.direction
+FROM gauge_instances gi
+JOIN gauge_templates gt ON gi.template_id = gt.id
+WHERE gt.active = true
+  AND ((gt.frequency = 'weekly' AND gi.period_start = ?) 
+    OR (gt.frequency = 'bi-weekly' AND gi.period_start = ?)
+    OR (gt.frequency = 'monthly' AND gi.period_start = ?))
+ORDER BY gt.name;
 
 -- name: GetCurrentValue :one
 SELECT CAST(COALESCE(
@@ -38,7 +76,7 @@ SELECT CAST(COALESCE(
 
 -- name: CreateGaugeValue :exec
 INSERT INTO gauge_values (gauge_id, value, date)
-VALUES (?, CAST(? AS REAL), ?);
+VALUES (?, ?, ?);
 
 -- name: GetGaugeValues :many
 SELECT * FROM gauge_values 

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -54,8 +54,8 @@ WHERE id = ?;
 DELETE FROM gauge_instances WHERE id = ?;
 
 -- name: InstanceExistsForPeriod :one
-SELECT COUNT(*) FROM gauge_instances 
-WHERE template_id = ? AND period_start = ?;
+SELECT EXISTS(SELECT 1 FROM gauge_instances 
+WHERE template_id = ? AND period_start = ?) as instance_exists;
 
 -- Dashboard and Current Period Queries
 -- name: ListCurrentPeriodGaugeInstances :many

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -244,8 +244,8 @@ func (q *Queries) GetGaugeValues(ctx context.Context, gaugeID int64) ([]GaugeVal
 }
 
 const instanceExistsForPeriod = `-- name: InstanceExistsForPeriod :one
-SELECT COUNT(*) FROM gauge_instances 
-WHERE template_id = ? AND period_start = ?
+SELECT EXISTS(SELECT 1 FROM gauge_instances 
+WHERE template_id = ? AND period_start = ?) as instance_exists
 `
 
 type InstanceExistsForPeriodParams struct {
@@ -255,9 +255,9 @@ type InstanceExistsForPeriodParams struct {
 
 func (q *Queries) InstanceExistsForPeriod(ctx context.Context, arg InstanceExistsForPeriodParams) (int64, error) {
 	row := q.db.QueryRowContext(ctx, instanceExistsForPeriod, arg.TemplateID, arg.PeriodStart)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
+	var instance_exists int64
+	err := row.Scan(&instance_exists)
+	return instance_exists, err
 }
 
 const listActiveGaugeTemplates = `-- name: ListActiveGaugeTemplates :many

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -11,13 +11,38 @@ import (
 	"time"
 )
 
-const createGauge = `-- name: CreateGauge :one
-INSERT INTO gauges (name, description, target, value, unit, icon, frequency, direction)
-VALUES (?, ?, ?, 0, ?, ?, ?, ?)
-RETURNING id, name, description, target, value, unit, icon, frequency, direction, created_at, updated_at
+const createGaugeInstance = `-- name: CreateGaugeInstance :one
+INSERT INTO gauge_instances (template_id, period_start, value)
+VALUES (?, ?, 0)
+RETURNING id, template_id, period_start, value, created_at, updated_at
 `
 
-type CreateGaugeParams struct {
+type CreateGaugeInstanceParams struct {
+	TemplateID  int64     `json:"template_id"`
+	PeriodStart time.Time `json:"period_start"`
+}
+
+func (q *Queries) CreateGaugeInstance(ctx context.Context, arg CreateGaugeInstanceParams) (GaugeInstance, error) {
+	row := q.db.QueryRowContext(ctx, createGaugeInstance, arg.TemplateID, arg.PeriodStart)
+	var i GaugeInstance
+	err := row.Scan(
+		&i.ID,
+		&i.TemplateID,
+		&i.PeriodStart,
+		&i.Value,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const createGaugeTemplate = `-- name: CreateGaugeTemplate :one
+INSERT INTO gauge_templates (name, description, target, unit, icon, frequency, direction, active)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, name, description, target, unit, icon, frequency, direction, active, created_at, updated_at
+`
+
+type CreateGaugeTemplateParams struct {
 	Name        string         `json:"name"`
 	Description sql.NullString `json:"description"`
 	Target      float64        `json:"target"`
@@ -25,10 +50,11 @@ type CreateGaugeParams struct {
 	Icon        string         `json:"icon"`
 	Frequency   string         `json:"frequency"`
 	Direction   string         `json:"direction"`
+	Active      bool           `json:"active"`
 }
 
-func (q *Queries) CreateGauge(ctx context.Context, arg CreateGaugeParams) (Gauge, error) {
-	row := q.db.QueryRowContext(ctx, createGauge,
+func (q *Queries) CreateGaugeTemplate(ctx context.Context, arg CreateGaugeTemplateParams) (GaugeTemplate, error) {
+	row := q.db.QueryRowContext(ctx, createGaugeTemplate,
 		arg.Name,
 		arg.Description,
 		arg.Target,
@@ -36,18 +62,19 @@ func (q *Queries) CreateGauge(ctx context.Context, arg CreateGaugeParams) (Gauge
 		arg.Icon,
 		arg.Frequency,
 		arg.Direction,
+		arg.Active,
 	)
-	var i Gauge
+	var i GaugeTemplate
 	err := row.Scan(
 		&i.ID,
 		&i.Name,
 		&i.Description,
 		&i.Target,
-		&i.Value,
 		&i.Unit,
 		&i.Icon,
 		&i.Frequency,
 		&i.Direction,
+		&i.Active,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -56,26 +83,35 @@ func (q *Queries) CreateGauge(ctx context.Context, arg CreateGaugeParams) (Gauge
 
 const createGaugeValue = `-- name: CreateGaugeValue :exec
 INSERT INTO gauge_values (gauge_id, value, date)
-VALUES (?, CAST(? AS REAL), ?)
+VALUES (?, ?, ?)
 `
 
 type CreateGaugeValueParams struct {
 	GaugeID int64     `json:"gauge_id"`
-	Column2 float64   `json:"column_2"`
+	Value   float64   `json:"value"`
 	Date    time.Time `json:"date"`
 }
 
 func (q *Queries) CreateGaugeValue(ctx context.Context, arg CreateGaugeValueParams) error {
-	_, err := q.db.ExecContext(ctx, createGaugeValue, arg.GaugeID, arg.Column2, arg.Date)
+	_, err := q.db.ExecContext(ctx, createGaugeValue, arg.GaugeID, arg.Value, arg.Date)
 	return err
 }
 
-const deleteGauge = `-- name: DeleteGauge :exec
-DELETE FROM gauges WHERE id = ?
+const deleteGaugeInstance = `-- name: DeleteGaugeInstance :exec
+DELETE FROM gauge_instances WHERE id = ?
 `
 
-func (q *Queries) DeleteGauge(ctx context.Context, id int64) error {
-	_, err := q.db.ExecContext(ctx, deleteGauge, id)
+func (q *Queries) DeleteGaugeInstance(ctx context.Context, id int64) error {
+	_, err := q.db.ExecContext(ctx, deleteGaugeInstance, id)
+	return err
+}
+
+const deleteGaugeTemplate = `-- name: DeleteGaugeTemplate :exec
+DELETE FROM gauge_templates WHERE id = ?
+`
+
+func (q *Queries) DeleteGaugeTemplate(ctx context.Context, id int64) error {
+	_, err := q.db.ExecContext(ctx, deleteGaugeTemplate, id)
 	return err
 }
 
@@ -91,29 +127,6 @@ func (q *Queries) GetCurrentValue(ctx context.Context, gaugeID int64) (float64, 
 	var value float64
 	err := row.Scan(&value)
 	return value, err
-}
-
-const getGauge = `-- name: GetGauge :one
-SELECT id, name, description, target, value, unit, icon, frequency, direction, created_at, updated_at FROM gauges WHERE id = ? LIMIT 1
-`
-
-func (q *Queries) GetGauge(ctx context.Context, id int64) (Gauge, error) {
-	row := q.db.QueryRowContext(ctx, getGauge, id)
-	var i Gauge
-	err := row.Scan(
-		&i.ID,
-		&i.Name,
-		&i.Description,
-		&i.Target,
-		&i.Value,
-		&i.Unit,
-		&i.Icon,
-		&i.Frequency,
-		&i.Direction,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
 }
 
 const getGaugeHistory = `-- name: GetGaugeHistory :many
@@ -153,6 +166,49 @@ func (q *Queries) GetGaugeHistory(ctx context.Context, gaugeID int64) ([]GetGaug
 	return items, nil
 }
 
+const getGaugeInstance = `-- name: GetGaugeInstance :one
+SELECT id, template_id, period_start, value, created_at, updated_at FROM gauge_instances WHERE id = ? LIMIT 1
+`
+
+// Gauge Instances CRUD Operations
+func (q *Queries) GetGaugeInstance(ctx context.Context, id int64) (GaugeInstance, error) {
+	row := q.db.QueryRowContext(ctx, getGaugeInstance, id)
+	var i GaugeInstance
+	err := row.Scan(
+		&i.ID,
+		&i.TemplateID,
+		&i.PeriodStart,
+		&i.Value,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getGaugeTemplate = `-- name: GetGaugeTemplate :one
+SELECT id, name, description, target, unit, icon, frequency, direction, active, created_at, updated_at FROM gauge_templates WHERE id = ? LIMIT 1
+`
+
+// Gauge Templates CRUD Operations
+func (q *Queries) GetGaugeTemplate(ctx context.Context, id int64) (GaugeTemplate, error) {
+	row := q.db.QueryRowContext(ctx, getGaugeTemplate, id)
+	var i GaugeTemplate
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Description,
+		&i.Target,
+		&i.Unit,
+		&i.Icon,
+		&i.Frequency,
+		&i.Direction,
+		&i.Active,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getGaugeValues = `-- name: GetGaugeValues :many
 SELECT id, gauge_id, value, date FROM gauge_values 
 WHERE gauge_id = ?
@@ -187,29 +243,46 @@ func (q *Queries) GetGaugeValues(ctx context.Context, gaugeID int64) ([]GaugeVal
 	return items, nil
 }
 
-const listGauges = `-- name: ListGauges :many
-SELECT id, name, description, target, value, unit, icon, frequency, direction, created_at, updated_at FROM gauges ORDER BY name
+const instanceExistsForPeriod = `-- name: InstanceExistsForPeriod :one
+SELECT COUNT(*) FROM gauge_instances 
+WHERE template_id = ? AND period_start = ?
 `
 
-func (q *Queries) ListGauges(ctx context.Context) ([]Gauge, error) {
-	rows, err := q.db.QueryContext(ctx, listGauges)
+type InstanceExistsForPeriodParams struct {
+	TemplateID  int64     `json:"template_id"`
+	PeriodStart time.Time `json:"period_start"`
+}
+
+func (q *Queries) InstanceExistsForPeriod(ctx context.Context, arg InstanceExistsForPeriodParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, instanceExistsForPeriod, arg.TemplateID, arg.PeriodStart)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const listActiveGaugeTemplates = `-- name: ListActiveGaugeTemplates :many
+SELECT id, name, description, target, unit, icon, frequency, direction, active, created_at, updated_at FROM gauge_templates WHERE active = true ORDER BY name
+`
+
+func (q *Queries) ListActiveGaugeTemplates(ctx context.Context) ([]GaugeTemplate, error) {
+	rows, err := q.db.QueryContext(ctx, listActiveGaugeTemplates)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []Gauge{}
+	items := []GaugeTemplate{}
 	for rows.Next() {
-		var i Gauge
+		var i GaugeTemplate
 		if err := rows.Scan(
 			&i.ID,
 			&i.Name,
 			&i.Description,
 			&i.Target,
-			&i.Value,
 			&i.Unit,
 			&i.Icon,
 			&i.Frequency,
 			&i.Direction,
+			&i.Active,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -226,20 +299,30 @@ func (q *Queries) ListGauges(ctx context.Context) ([]Gauge, error) {
 	return items, nil
 }
 
-const updateGauge = `-- name: UpdateGauge :exec
-UPDATE gauges
-SET name = ?,
-    description = ?,
-    target = ?,
-    unit = ?,
-    icon = ?,
-    frequency = ?,
-    direction = ?,
-    updated_at = CURRENT_TIMESTAMP
-WHERE id = ?
+const listCurrentPeriodGaugeInstances = `-- name: ListCurrentPeriodGaugeInstances :many
+SELECT gi.id, gi.template_id, gi.period_start, gi.value, gi.created_at, gi.updated_at, gt.name, gt.description, gt.target, gt.unit, gt.icon, gt.frequency, gt.direction
+FROM gauge_instances gi
+JOIN gauge_templates gt ON gi.template_id = gt.id
+WHERE gt.active = true
+  AND ((gt.frequency = 'weekly' AND gi.period_start = ?) 
+    OR (gt.frequency = 'bi-weekly' AND gi.period_start = ?)
+    OR (gt.frequency = 'monthly' AND gi.period_start = ?))
+ORDER BY gt.name
 `
 
-type UpdateGaugeParams struct {
+type ListCurrentPeriodGaugeInstancesParams struct {
+	PeriodStart   time.Time `json:"period_start"`
+	PeriodStart_2 time.Time `json:"period_start_2"`
+	PeriodStart_3 time.Time `json:"period_start_3"`
+}
+
+type ListCurrentPeriodGaugeInstancesRow struct {
+	ID          int64          `json:"id"`
+	TemplateID  int64          `json:"template_id"`
+	PeriodStart time.Time      `json:"period_start"`
+	Value       float64        `json:"value"`
+	CreatedAt   sql.NullTime   `json:"created_at"`
+	UpdatedAt   sql.NullTime   `json:"updated_at"`
 	Name        string         `json:"name"`
 	Description sql.NullString `json:"description"`
 	Target      float64        `json:"target"`
@@ -247,11 +330,198 @@ type UpdateGaugeParams struct {
 	Icon        string         `json:"icon"`
 	Frequency   string         `json:"frequency"`
 	Direction   string         `json:"direction"`
+}
+
+// Dashboard and Current Period Queries
+func (q *Queries) ListCurrentPeriodGaugeInstances(ctx context.Context, arg ListCurrentPeriodGaugeInstancesParams) ([]ListCurrentPeriodGaugeInstancesRow, error) {
+	rows, err := q.db.QueryContext(ctx, listCurrentPeriodGaugeInstances, arg.PeriodStart, arg.PeriodStart_2, arg.PeriodStart_3)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListCurrentPeriodGaugeInstancesRow{}
+	for rows.Next() {
+		var i ListCurrentPeriodGaugeInstancesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.TemplateID,
+			&i.PeriodStart,
+			&i.Value,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.Name,
+			&i.Description,
+			&i.Target,
+			&i.Unit,
+			&i.Icon,
+			&i.Frequency,
+			&i.Direction,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listGaugeInstances = `-- name: ListGaugeInstances :many
+SELECT id, template_id, period_start, value, created_at, updated_at FROM gauge_instances ORDER BY period_start DESC
+`
+
+func (q *Queries) ListGaugeInstances(ctx context.Context) ([]GaugeInstance, error) {
+	rows, err := q.db.QueryContext(ctx, listGaugeInstances)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GaugeInstance{}
+	for rows.Next() {
+		var i GaugeInstance
+		if err := rows.Scan(
+			&i.ID,
+			&i.TemplateID,
+			&i.PeriodStart,
+			&i.Value,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listGaugeInstancesByTemplate = `-- name: ListGaugeInstancesByTemplate :many
+SELECT id, template_id, period_start, value, created_at, updated_at FROM gauge_instances WHERE template_id = ? ORDER BY period_start DESC
+`
+
+func (q *Queries) ListGaugeInstancesByTemplate(ctx context.Context, templateID int64) ([]GaugeInstance, error) {
+	rows, err := q.db.QueryContext(ctx, listGaugeInstancesByTemplate, templateID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GaugeInstance{}
+	for rows.Next() {
+		var i GaugeInstance
+		if err := rows.Scan(
+			&i.ID,
+			&i.TemplateID,
+			&i.PeriodStart,
+			&i.Value,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listGaugeTemplates = `-- name: ListGaugeTemplates :many
+SELECT id, name, description, target, unit, icon, frequency, direction, active, created_at, updated_at FROM gauge_templates ORDER BY name
+`
+
+func (q *Queries) ListGaugeTemplates(ctx context.Context) ([]GaugeTemplate, error) {
+	rows, err := q.db.QueryContext(ctx, listGaugeTemplates)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GaugeTemplate{}
+	for rows.Next() {
+		var i GaugeTemplate
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.Description,
+			&i.Target,
+			&i.Unit,
+			&i.Icon,
+			&i.Frequency,
+			&i.Direction,
+			&i.Active,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const updateGaugeInstanceValue = `-- name: UpdateGaugeInstanceValue :exec
+UPDATE gauge_instances
+SET value = ?,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = ?
+`
+
+type UpdateGaugeInstanceValueParams struct {
+	Value float64 `json:"value"`
+	ID    int64   `json:"id"`
+}
+
+func (q *Queries) UpdateGaugeInstanceValue(ctx context.Context, arg UpdateGaugeInstanceValueParams) error {
+	_, err := q.db.ExecContext(ctx, updateGaugeInstanceValue, arg.Value, arg.ID)
+	return err
+}
+
+const updateGaugeTemplate = `-- name: UpdateGaugeTemplate :exec
+UPDATE gauge_templates
+SET name = ?,
+    description = ?,
+    target = ?,
+    unit = ?,
+    icon = ?,
+    frequency = ?,
+    direction = ?,
+    active = ?,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = ?
+`
+
+type UpdateGaugeTemplateParams struct {
+	Name        string         `json:"name"`
+	Description sql.NullString `json:"description"`
+	Target      float64        `json:"target"`
+	Unit        string         `json:"unit"`
+	Icon        string         `json:"icon"`
+	Frequency   string         `json:"frequency"`
+	Direction   string         `json:"direction"`
+	Active      bool           `json:"active"`
 	ID          int64          `json:"id"`
 }
 
-func (q *Queries) UpdateGauge(ctx context.Context, arg UpdateGaugeParams) error {
-	_, err := q.db.ExecContext(ctx, updateGauge,
+func (q *Queries) UpdateGaugeTemplate(ctx context.Context, arg UpdateGaugeTemplateParams) error {
+	_, err := q.db.ExecContext(ctx, updateGaugeTemplate,
 		arg.Name,
 		arg.Description,
 		arg.Target,
@@ -259,24 +529,8 @@ func (q *Queries) UpdateGauge(ctx context.Context, arg UpdateGaugeParams) error 
 		arg.Icon,
 		arg.Frequency,
 		arg.Direction,
+		arg.Active,
 		arg.ID,
 	)
-	return err
-}
-
-const updateGaugeValue = `-- name: UpdateGaugeValue :exec
-UPDATE gauges
-SET value = ?,
-    updated_at = CURRENT_TIMESTAMP
-WHERE id = ?
-`
-
-type UpdateGaugeValueParams struct {
-	Value float64 `json:"value"`
-	ID    int64   `json:"id"`
-}
-
-func (q *Queries) UpdateGaugeValue(ctx context.Context, arg UpdateGaugeValueParams) error {
-	_, err := q.db.ExecContext(ctx, updateGaugeValue, arg.Value, arg.ID)
 	return err
 }

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -25,14 +25,82 @@ func setupTestDB(t *testing.T) (*Queries, func()) {
 	return q, cleanup
 }
 
-func TestListGauges_Empty(t *testing.T) {
+func TestListGaugeTemplates_Empty(t *testing.T) {
 	q, cleanup := setupTestDB(t)
 	defer cleanup()
 
 	ctx := context.Background()
-	gauges, err := q.ListGauges(ctx)
+	templates, err := q.ListGaugeTemplates(ctx)
 	require.NoError(t, err)
-	require.Len(t, gauges, 0)
+	require.Len(t, templates, 0)
+}
+
+func TestCreateGaugeTemplate(t *testing.T) {
+	q, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	
+	params := CreateGaugeTemplateParams{
+		Name:        "Test Gauge",
+		Description: sql.NullString{String: "Test Description", Valid: true},
+		Target:      10.0,
+		Unit:        "hours",
+		Icon:        "chart-bar",
+		Frequency:   "weekly",
+		Direction:   "under",
+		Active:      true,
+	}
+	
+	template, err := q.CreateGaugeTemplate(ctx, params)
+	require.NoError(t, err)
+	require.Equal(t, "Test Gauge", template.Name)
+	require.Equal(t, "weekly", template.Frequency)
+	require.True(t, template.Active)
+}
+
+func TestListActiveGaugeTemplates(t *testing.T) {
+	q, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	
+	// Create an active template
+	activeParams := CreateGaugeTemplateParams{
+		Name:        "Active Gauge",
+		Description: sql.NullString{String: "Active Description", Valid: true},
+		Target:      5.0,
+		Unit:        "times",
+		Icon:        "chart-bar",
+		Frequency:   "monthly",
+		Direction:   "under",
+		Active:      true,
+	}
+	
+	// Create an inactive template
+	inactiveParams := CreateGaugeTemplateParams{
+		Name:        "Inactive Gauge",
+		Description: sql.NullString{String: "Inactive Description", Valid: true},
+		Target:      3.0,
+		Unit:        "days",
+		Icon:        "chart-bar",
+		Frequency:   "weekly",
+		Direction:   "under",
+		Active:      false,
+	}
+	
+	_, err := q.CreateGaugeTemplate(ctx, activeParams)
+	require.NoError(t, err)
+	
+	_, err = q.CreateGaugeTemplate(ctx, inactiveParams)
+	require.NoError(t, err)
+	
+	// List only active templates
+	activeTemplates, err := q.ListActiveGaugeTemplates(ctx)
+	require.NoError(t, err)
+	require.Len(t, activeTemplates, 1)
+	require.Equal(t, "Active Gauge", activeTemplates[0].Name)
+	require.True(t, activeTemplates[0].Active)
 }
 
 // Add more DB tests for edge cases and with inserted data

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -1,24 +1,43 @@
 DROP TABLE IF EXISTS gauge_values;
-DROP TABLE IF EXISTS gauges;
+DROP TABLE IF EXISTS gauge_instances;
+DROP TABLE IF EXISTS gauge_templates;
 
-CREATE TABLE gauges (
+-- Gauge templates (user-created configurations)
+CREATE TABLE gauge_templates (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL,
     description TEXT,
     target REAL NOT NULL,
-    value REAL NOT NULL DEFAULT 0,
     unit TEXT NOT NULL,
     icon TEXT NOT NULL DEFAULT 'chart-bar',
-    frequency TEXT NOT NULL DEFAULT 'weekly',
+    frequency TEXT NOT NULL, -- 'weekly', 'bi-weekly', 'monthly'
     direction TEXT NOT NULL DEFAULT 'under',
+    active BOOLEAN DEFAULT false,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Gauge instances (auto-generated for specific time periods)
+CREATE TABLE gauge_instances (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    template_id INTEGER NOT NULL REFERENCES gauge_templates(id) ON DELETE CASCADE,
+    period_start DATE NOT NULL,
+    value REAL NOT NULL DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Gauge values (historical log of value changes within each instance)
 CREATE TABLE gauge_values (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     gauge_id INTEGER NOT NULL,
     value REAL NOT NULL,
     date DATETIME NOT NULL,
-    FOREIGN KEY (gauge_id) REFERENCES gauges(id) ON DELETE CASCADE
+    FOREIGN KEY (gauge_id) REFERENCES gauge_instances(id) ON DELETE CASCADE
 );
+
+-- Create indexes for performance
+CREATE INDEX idx_gauge_templates_active ON gauge_templates(active);
+CREATE INDEX idx_gauge_templates_frequency ON gauge_templates(frequency);
+CREATE INDEX idx_gauge_instances_template ON gauge_instances(template_id);
+CREATE INDEX idx_gauge_instances_period ON gauge_instances(period_start);

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -10,8 +10,8 @@ CREATE TABLE gauge_templates (
     target REAL NOT NULL,
     unit TEXT NOT NULL,
     icon TEXT NOT NULL DEFAULT 'chart-bar',
-    frequency TEXT NOT NULL, -- 'weekly', 'bi-weekly', 'monthly'
-    direction TEXT NOT NULL DEFAULT 'under',
+    frequency TEXT NOT NULL CHECK (frequency IN ('weekly', 'bi-weekly', 'monthly')),
+    direction TEXT NOT NULL DEFAULT 'under' CHECK (direction IN ('under', 'over')),
     active BOOLEAN DEFAULT false,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
@@ -41,3 +41,4 @@ CREATE INDEX idx_gauge_templates_active ON gauge_templates(active);
 CREATE INDEX idx_gauge_templates_frequency ON gauge_templates(frequency);
 CREATE INDEX idx_gauge_instances_template ON gauge_instances(template_id);
 CREATE INDEX idx_gauge_instances_period ON gauge_instances(period_start);
+CREATE UNIQUE INDEX idx_gauge_instances_template_period ON gauge_instances(template_id, period_start);

--- a/internal/models/gauge.go
+++ b/internal/models/gauge.go
@@ -19,41 +19,67 @@ type MonthlyValue struct {
 	AverageValue float64 `json:"average_value"`
 }
 
-// GaugeWithValue combines a gauge with its latest value
-type GaugeWithValue struct {
-	*db.Gauge
+// GaugeInstanceWithStatus combines a gauge instance with its status
+type GaugeInstanceWithStatus struct {
+	*db.ListCurrentPeriodGaugeInstancesRow
 	Status *GaugeStatus `json:"status"`
 }
 
-// GaugeHistory represents historical data for a gauge
+// GaugeTemplateWithStatus combines a gauge template with its status
+type GaugeTemplateWithStatus struct {
+	*db.GaugeTemplate
+	Status *GaugeStatus `json:"status"`
+}
+
+// GaugeHistory represents historical data for a gauge instance
 type GaugeHistory struct {
-	*db.Gauge
+	InstanceID   int64          `json:"instance_id"`
+	TemplateName string         `json:"template_name"`
 	Month        string         `json:"month"`
 	AverageValue float64        `json:"average_value"`
 	Values       []MonthlyValue `json:"values"`
 }
 
-// NewGaugeWithValue creates a new GaugeWithValue instance
-func NewGaugeWithValue(gauge *db.Gauge) *GaugeWithValue {
+// NewGaugeInstanceWithStatus creates a new GaugeInstanceWithStatus instance
+func NewGaugeInstanceWithStatus(instance *db.ListCurrentPeriodGaugeInstancesRow) *GaugeInstanceWithStatus {
 	percent := 0.0
-	if gauge.Target > 0 {
-		percent = (gauge.Value / gauge.Target) * 100
+	if instance.Target > 0 {
+		percent = (instance.Value / instance.Target) * 100
 	}
 
-	return &GaugeWithValue{
-		Gauge: gauge,
+	return &GaugeInstanceWithStatus{
+		ListCurrentPeriodGaugeInstancesRow: instance,
 		Status: &GaugeStatus{
-			Value:   gauge.Value,
-			Target:  gauge.Target,
-			Unit:    gauge.Unit,
-			Icon:    gauge.Icon,
+			Value:   instance.Value,
+			Target:  instance.Target,
+			Unit:    instance.Unit,
+			Icon:    instance.Icon,
+			Percent: percent,
+		},
+	}
+}
+
+// NewGaugeTemplateWithStatus creates a new GaugeTemplateWithStatus instance
+func NewGaugeTemplateWithStatus(template *db.GaugeTemplate, currentValue float64) *GaugeTemplateWithStatus {
+	percent := 0.0
+	if template.Target > 0 {
+		percent = (currentValue / template.Target) * 100
+	}
+
+	return &GaugeTemplateWithStatus{
+		GaugeTemplate: template,
+		Status: &GaugeStatus{
+			Value:   currentValue,
+			Target:  template.Target,
+			Unit:    template.Unit,
+			Icon:    template.Icon,
 			Percent: percent,
 		},
 	}
 }
 
 // NewGaugeHistory creates a new GaugeHistory instance
-func NewGaugeHistory(gauge *db.Gauge, history []db.GetGaugeHistoryRow) *GaugeHistory {
+func NewGaugeHistory(instanceID int64, templateName string, history []db.GetGaugeHistoryRow) *GaugeHistory {
 	values := make([]MonthlyValue, len(history))
 	for i, h := range history {
 		month := ""
@@ -69,8 +95,9 @@ func NewGaugeHistory(gauge *db.Gauge, history []db.GetGaugeHistoryRow) *GaugeHis
 	}
 
 	return &GaugeHistory{
-		Gauge:  gauge,
-		Month:  "",
-		Values: values,
+		InstanceID:   instanceID,
+		TemplateName: templateName,
+		Month:        "",
+		Values:       values,
 	}
 }

--- a/internal/models/gauge.go
+++ b/internal/models/gauge.go
@@ -42,6 +42,10 @@ type GaugeHistory struct {
 
 // NewGaugeInstanceWithStatus creates a new GaugeInstanceWithStatus instance
 func NewGaugeInstanceWithStatus(instance *db.ListCurrentPeriodGaugeInstancesRow) *GaugeInstanceWithStatus {
+	if instance == nil {
+		return nil
+	}
+	
 	percent := 0.0
 	if instance.Target > 0 {
 		percent = (instance.Value / instance.Target) * 100
@@ -61,6 +65,10 @@ func NewGaugeInstanceWithStatus(instance *db.ListCurrentPeriodGaugeInstancesRow)
 
 // NewGaugeTemplateWithStatus creates a new GaugeTemplateWithStatus instance
 func NewGaugeTemplateWithStatus(template *db.GaugeTemplate, currentValue float64) *GaugeTemplateWithStatus {
+	if template == nil {
+		return nil
+	}
+	
 	percent := 0.0
 	if template.Target > 0 {
 		percent = (currentValue / template.Target) * 100

--- a/internal/models/gauge_test.go
+++ b/internal/models/gauge_test.go
@@ -8,26 +8,187 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewGaugeWithValue(t *testing.T) {
+func TestNewGaugeTemplateWithStatus(t *testing.T) {
 	tests := []struct {
-		name     string
-		gauge    *db.Gauge
-		expected *GaugeWithValue
+		name         string
+		template     *db.GaugeTemplate
+		currentValue float64
+		expected     *GaugeTemplateWithStatus
 	}{
 		{
 			name: "calculate percentage - target > 0",
-			gauge: &db.Gauge{
+			template: &db.GaugeTemplate{
 				ID:     1,
-				Name:   "Test Gauge",
+				Name:   "Test Template",
+				Target: 100,
+				Unit:   "units",
+				Icon:   "star",
+			},
+			currentValue: 80,
+			expected: &GaugeTemplateWithStatus{
+				GaugeTemplate: &db.GaugeTemplate{
+					ID:     1,
+					Name:   "Test Template",
+					Target: 100,
+					Unit:   "units",
+					Icon:   "star",
+				},
+				Status: &GaugeStatus{
+					Value:   80,
+					Target:  100,
+					Unit:    "units",
+					Icon:    "star",
+					Percent: 80,
+				},
+			},
+		},
+		{
+			name: "zero target - no percentage",
+			template: &db.GaugeTemplate{
+				ID:     2,
+				Name:   "Zero Target",
+				Target: 0,
+				Unit:   "units",
+				Icon:   "warning",
+			},
+			currentValue: 80,
+			expected: &GaugeTemplateWithStatus{
+				GaugeTemplate: &db.GaugeTemplate{
+					ID:     2,
+					Name:   "Zero Target",
+					Target: 0,
+					Unit:   "units",
+					Icon:   "warning",
+				},
+				Status: &GaugeStatus{
+					Value:   80,
+					Target:  0,
+					Unit:    "units",
+					Icon:    "warning",
+					Percent: 0,
+				},
+			},
+		},
+		{
+			name:         "nil template",
+			template:     nil,
+			currentValue: 80,
+			expected:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewGaugeTemplateWithStatus(tt.template, tt.currentValue)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestNewGaugeHistory(t *testing.T) {
+	tests := []struct {
+		name         string
+		instanceID   int64
+		templateName string
+		history      []db.GetGaugeHistoryRow
+		expected     *GaugeHistory
+	}{
+		{
+			name:         "multiple history entries",
+			instanceID:   1,
+			templateName: "Test Template",
+			history: []db.GetGaugeHistoryRow{
+				{
+					Month:        "2025-03",
+					AverageValue: 75.5,
+				},
+				{
+					Month:        "2025-02",
+					AverageValue: 82.3,
+				},
+			},
+			expected: &GaugeHistory{
+				InstanceID:   1,
+				TemplateName: "Test Template",
+				Month:        "",
+				Values: []MonthlyValue{
+					{
+						Month:        "2025-03",
+						AverageValue: 75.5,
+					},
+					{
+						Month:        "2025-02",
+						AverageValue: 82.3,
+					},
+				},
+			},
+		},
+		{
+			name:         "empty history",
+			instanceID:   2,
+			templateName: "Empty Template",
+			history:      []db.GetGaugeHistoryRow{},
+			expected: &GaugeHistory{
+				InstanceID:   2,
+				TemplateName: "Empty Template",
+				Month:        "",
+				Values:       []MonthlyValue{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewGaugeHistory(tt.instanceID, tt.templateName, tt.history)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestMonthTypeAssertion(t *testing.T) {
+	// Test with string month
+	history := []db.GetGaugeHistoryRow{
+		{
+			Month:        "2025-03",
+			AverageValue: 75.5,
+		},
+	}
+
+	result := NewGaugeHistory(1, "Test Template", history)
+	assert.Equal(t, "2025-03", result.Values[0].Month)
+
+	// Test with nil month
+	historyNil := []db.GetGaugeHistoryRow{
+		{
+			Month:        nil,
+			AverageValue: 82.3,
+		},
+	}
+
+	resultNil := NewGaugeHistory(2, "Test Template", historyNil)
+	assert.Equal(t, "", resultNil.Values[0].Month)
+}
+
+func TestNewGaugeInstanceWithStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance *db.ListCurrentPeriodGaugeInstancesRow
+		expected *GaugeInstanceWithStatus
+	}{
+		{
+			name: "calculate percentage - target > 0",
+			instance: &db.ListCurrentPeriodGaugeInstancesRow{
+				ID:     1,
+				Name:   "Test Instance",
 				Value:  80,
 				Target: 100,
 				Unit:   "units",
 				Icon:   "star",
 			},
-			expected: &GaugeWithValue{
-				Gauge: &db.Gauge{
+			expected: &GaugeInstanceWithStatus{
+				ListCurrentPeriodGaugeInstancesRow: &db.ListCurrentPeriodGaugeInstancesRow{
 					ID:     1,
-					Name:   "Test Gauge",
+					Name:   "Test Instance",
 					Value:  80,
 					Target: 100,
 					Unit:   "units",
@@ -44,7 +205,7 @@ func TestNewGaugeWithValue(t *testing.T) {
 		},
 		{
 			name: "zero target - no percentage",
-			gauge: &db.Gauge{
+			instance: &db.ListCurrentPeriodGaugeInstancesRow{
 				ID:     2,
 				Name:   "Zero Target",
 				Value:  80,
@@ -52,8 +213,8 @@ func TestNewGaugeWithValue(t *testing.T) {
 				Unit:   "units",
 				Icon:   "warning",
 			},
-			expected: &GaugeWithValue{
-				Gauge: &db.Gauge{
+			expected: &GaugeInstanceWithStatus{
+				ListCurrentPeriodGaugeInstancesRow: &db.ListCurrentPeriodGaugeInstancesRow{
 					ID:     2,
 					Name:   "Zero Target",
 					Value:  80,
@@ -71,136 +232,16 @@ func TestNewGaugeWithValue(t *testing.T) {
 			},
 		},
 		{
-			name: "zero value - zero percentage",
-			gauge: &db.Gauge{
-				ID:     3,
-				Name:   "Zero Value",
-				Value:  0,
-				Target: 100,
-				Unit:   "units",
-				Icon:   "error",
-			},
-			expected: &GaugeWithValue{
-				Gauge: &db.Gauge{
-					ID:     3,
-					Name:   "Zero Value",
-					Value:  0,
-					Target: 100,
-					Unit:   "units",
-					Icon:   "error",
-				},
-				Status: &GaugeStatus{
-					Value:   0,
-					Target:  100,
-					Unit:    "units",
-					Icon:    "error",
-					Percent: 0,
-				},
-			},
+			name:     "nil instance",
+			instance: nil,
+			expected: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NewGaugeWithValue(tt.gauge)
+			got := NewGaugeInstanceWithStatus(tt.instance)
 			assert.Equal(t, tt.expected, got)
 		})
 	}
-}
-
-func TestNewGaugeHistory(t *testing.T) {
-	gauge := &db.Gauge{
-		ID:     1,
-		Name:   "Test Gauge",
-		Value:  80,
-		Target: 100,
-		Unit:   "units",
-		Icon:   "star",
-	}
-
-	tests := []struct {
-		name     string
-		gauge    *db.Gauge
-		history  []db.GetGaugeHistoryRow
-		expected *GaugeHistory
-	}{
-		{
-			name:  "multiple history entries",
-			gauge: gauge,
-			history: []db.GetGaugeHistoryRow{
-				{
-					Month:        "2025-03",
-					AverageValue: 75.5,
-				},
-				{
-					Month:        "2025-02",
-					AverageValue: 82.3,
-				},
-			},
-			expected: &GaugeHistory{
-				Gauge: gauge,
-				Month: "",
-				Values: []MonthlyValue{
-					{
-						Month:        "2025-03",
-						AverageValue: 75.5,
-					},
-					{
-						Month:        "2025-02",
-						AverageValue: 82.3,
-					},
-				},
-			},
-		},
-		{
-			name:    "empty history",
-			gauge:   gauge,
-			history: []db.GetGaugeHistoryRow{},
-			expected: &GaugeHistory{
-				Gauge:  gauge,
-				Month:  "",
-				Values: []MonthlyValue{},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := NewGaugeHistory(tt.gauge, tt.history)
-			assert.Equal(t, tt.expected, got)
-		})
-	}
-}
-
-func TestMonthTypeAssertion(t *testing.T) {
-	gauge := &db.Gauge{
-		ID:     1,
-		Name:   "Test Gauge",
-		Value:  80,
-		Target: 100,
-		Unit:   "units",
-		Icon:   "star",
-	}
-
-	// Test with string month
-	history := []db.GetGaugeHistoryRow{
-		{
-			Month:        "2025-03",
-			AverageValue: 75.5,
-		},
-	}
-
-	result := NewGaugeHistory(gauge, history)
-	assert.Equal(t, "2025-03", result.Values[0].Month)
-
-	// Test with nil month
-	historyNil := []db.GetGaugeHistoryRow{
-		{
-			Month:        nil,
-			AverageValue: 82.3,
-		},
-	}
-
-	resultNil := NewGaugeHistory(gauge, historyNil)
-	assert.Equal(t, "", resultNil.Values[0].Month)
 }

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -41,29 +41,47 @@ func NewTestDB(t *testing.T) *db.Queries {
 	return db.New(database)
 }
 
-// CreateTestGauge creates a test gauge and returns it
-func CreateTestGauge(t *testing.T, q *db.Queries) db.Gauge {
-	params := db.CreateGaugeParams{
+// CreateTestGaugeTemplate creates a test gauge template and returns it
+func CreateTestGaugeTemplate(t *testing.T, q *db.Queries) db.GaugeTemplate {
+	params := db.CreateGaugeTemplateParams{
 		Name:        "Test Gauge",
 		Description: sql.NullString{String: "Test Description", Valid: true},
 		Target:      100,
 		Unit:        "units",
 		Icon:        "star",
+		Frequency:   "weekly",
+		Direction:   "under",
+		Active:      true,
 	}
 
-	gauge, err := q.CreateGauge(context.Background(), params)
+	template, err := q.CreateGaugeTemplate(context.Background(), params)
 	if err != nil {
-		t.Fatalf("Failed to create test gauge: %v", err)
+		t.Fatalf("Failed to create test gauge template: %v", err)
 	}
 
-	return gauge
+	return template
+}
+
+// CreateTestGaugeInstance creates a test gauge instance and returns it
+func CreateTestGaugeInstance(t *testing.T, q *db.Queries, templateID int64, periodStart time.Time) db.GaugeInstance {
+	params := db.CreateGaugeInstanceParams{
+		TemplateID:  templateID,
+		PeriodStart: periodStart,
+	}
+
+	instance, err := q.CreateGaugeInstance(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Failed to create test gauge instance: %v", err)
+	}
+
+	return instance
 }
 
 // CreateTestGaugeValue creates a test gauge value
 func CreateTestGaugeValue(t *testing.T, q *db.Queries, gaugeID int64, value float64, date time.Time) error {
 	params := db.CreateGaugeValueParams{
 		GaugeID: gaugeID,
-		Column2: value,
+		Value:   value,
 		Date:    date,
 	}
 

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -11,7 +11,11 @@ sql:
         emit_interface: true
         emit_empty_slices: true
         overrides:
-          - column: "gauges.target"
+          - column: "gauge_templates.target"
+            go_type: "float64"
+          - column: "gauge_instances.value"
             go_type: "float64"
           - column: "gauge_values.value"
             go_type: "float64"
+          - column: "gauge_templates.active"
+            go_type: "bool"


### PR DESCRIPTION
- Updated schema.sql to separate gauge_templates and gauge_instances
- Added comprehensive CRUD operations for both templates and instances
- Updated existing gauge value queries to work with new structure
- Added frequency-based filtering query for dashboard
- Generated new Go models and interfaces with SQLC
- Updated all tests and mocks to work with new schema
- Added performance indexes for template and instance queries

This implements the foundation for frequency-based gauge filtering by separating user-created templates from time-period instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new structure for gauges, separating gauge templates (definitions) from gauge instances (period-based records).
  * Added support for managing active/inactive gauge templates and tracking values by period (weekly, bi-weekly, monthly).
  * Enhanced filtering and listing of gauge templates and instances, including active-only and current period queries.

* **Bug Fixes**
  * Improved data consistency by normalizing gauge storage and history tracking.

* **Tests**
  * Expanded and updated tests to cover gauge template creation, listing, and active status filtering.

* **Chores**
  * Updated database schema and configuration to support new gauge management features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->