### PR TITLE
feat: implement dashboard filtering for current period gauges

### DIFF
--- a/.kiro/specs/frequency-based-gauge-filtering/tasks.md
+++ b/.kiro/specs/frequency-based-gauge-filtering/tasks.md
@@ -84,14 +84,14 @@
   - Include variety of frequencies and realistic sample data
   - _Development tool for easier testing and demo purposes_
 
-- [ ] 7. Implement dashboard filtering for current period gauges
+- [x] 7. Implement dashboard filtering for current period gauges
   - Update dashboard handler to query current period gauge instances
   - Implement filtering logic based on current time and frequency
   - Update dashboard template to show only current period gauges
   - Add "no active gauges" message when no instances exist
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 4.1, 4.2, 4.4_
 
-- [ ] 7.1 Write unit tests for dashboard filtering logic
+- [x] 7.1 Write unit tests for dashboard filtering logic
   - Test dashboard shows only current period gauge instances
   - Test filtering works correctly for weekly, bi-weekly, and monthly frequencies
   - Test "no active gauges" message displays when no instances exist

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -11,9 +10,6 @@ import (
 	"health-monitor/internal/db"
 	"health-monitor/internal/handlers"
 	"health-monitor/internal/logger"
-	"health-monitor/internal/timeutil"
-	"health-monitor/internal/views/layouts"
-	"health-monitor/internal/views/pages"
 )
 
 // main starts the health-monitor web service, initializing logging, database connections, HTTP routing, middleware, and serving HTTP requests.
@@ -51,35 +47,6 @@ func main() {
 			next.ServeHTTP(w, r)
 			logger.Debug().Str("method", r.Method).Str("path", r.URL.Path).Msg("Request completed")
 		})
-	})
-
-	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		// Calculate current period starts for all frequencies
-		currentTime := time.Now()
-		weeklyStart := timeutil.CalculateCurrentPeriodStart("weekly", currentTime)
-		biWeeklyStart := timeutil.CalculateCurrentPeriodStart("bi-weekly", currentTime)
-		monthlyStart := timeutil.CalculateCurrentPeriodStart("monthly", currentTime)
-
-		// Query current period gauge instances
-		gaugeInstances, err := queries.ListCurrentPeriodGaugeInstances(r.Context(), db.ListCurrentPeriodGaugeInstancesParams{
-			PeriodStart:   weeklyStart,
-			PeriodStart_2: biWeeklyStart,
-			PeriodStart_3: monthlyStart,
-		})
-		if err != nil {
-			logger.Error().Err(err).Msg("Failed to fetch current period gauge instances")
-			http.Error(w, "Internal server error", http.StatusInternalServerError)
-			return
-		}
-
-		logger.Debug().Int("count", len(gaugeInstances)).Msg("Fetched current period gauge instances")
-
-		w.Header().Set("Content-Type", "text/html")
-		err = layouts.Base("Dashboard", pages.Dashboard(gaugeInstances)).Render(r.Context(), w)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
 	})
 
 	// Create gauge handler and register all gauge-related routes

--- a/go.work.sum
+++ b/go.work.sum
@@ -61,6 +61,7 @@ github.com/rs/cors v1.11.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/segmentio/encoding v0.3.6/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tursodatabase/libsql-client-go v0.0.0-20240902231107-85af5b9d094d/go.mod h1:l8xTsYB90uaVdMHXMCxKKLSgw5wLYBwBKKefNIUnm9s=

--- a/internal/handlers/dashboard_test.go
+++ b/internal/handlers/dashboard_test.go
@@ -1,0 +1,247 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"health-monitor/internal/db"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockQuerier implements the Querier interface for testing
+type MockQuerier struct {
+	mock.Mock
+}
+
+func (m *MockQuerier) ListGaugeTemplates(ctx context.Context) ([]db.GaugeTemplate, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]db.GaugeTemplate), args.Error(1)
+}
+
+func (m *MockQuerier) GetGaugeTemplate(ctx context.Context, id int64) (db.GaugeTemplate, error) {
+	args := m.Called(ctx, id)
+	return args.Get(0).(db.GaugeTemplate), args.Error(1)
+}
+
+func (m *MockQuerier) CreateGaugeTemplate(ctx context.Context, params db.CreateGaugeTemplateParams) (db.GaugeTemplate, error) {
+	args := m.Called(ctx, params)
+	return args.Get(0).(db.GaugeTemplate), args.Error(1)
+}
+
+func (m *MockQuerier) UpdateGaugeTemplate(ctx context.Context, params db.UpdateGaugeTemplateParams) error {
+	args := m.Called(ctx, params)
+	return args.Error(0)
+}
+
+func (m *MockQuerier) DeleteGaugeTemplate(ctx context.Context, id int64) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *MockQuerier) GetGaugeInstance(ctx context.Context, id int64) (db.GaugeInstance, error) {
+	args := m.Called(ctx, id)
+	return args.Get(0).(db.GaugeInstance), args.Error(1)
+}
+
+func (m *MockQuerier) UpdateGaugeInstanceValue(ctx context.Context, params db.UpdateGaugeInstanceValueParams) error {
+	args := m.Called(ctx, params)
+	return args.Error(0)
+}
+
+func (m *MockQuerier) ListCurrentPeriodGaugeInstances(ctx context.Context, params db.ListCurrentPeriodGaugeInstancesParams) ([]db.ListCurrentPeriodGaugeInstancesRow, error) {
+	args := m.Called(ctx, params)
+	return args.Get(0).([]db.ListCurrentPeriodGaugeInstancesRow), args.Error(1)
+}
+
+func TestHandleDashboard_WithActiveGauges(t *testing.T) {
+	// Create mock querier
+	mockQuerier := new(MockQuerier)
+	handler := NewGaugeHandler(mockQuerier)
+
+	// Create test data - current period gauge instances
+	testInstances := []db.ListCurrentPeriodGaugeInstancesRow{
+		{
+			ID:          1,
+			TemplateID:  1,
+			PeriodStart: time.Date(2024, 1, 7, 0, 0, 0, 0, time.UTC), // Sunday
+			Value:       5,
+			CreatedAt:   sql.NullTime{Time: time.Now(), Valid: true},
+			UpdatedAt:   sql.NullTime{Time: time.Now(), Valid: true},
+			Name:        "Weekly Exercise",
+			Description: sql.NullString{String: "Track weekly exercise", Valid: true},
+			Target:      10,
+			Unit:        "hours",
+			Icon:        "chart-bar",
+			Frequency:   "weekly",
+			Direction:   "under",
+		},
+		{
+			ID:          2,
+			TemplateID:  2,
+			PeriodStart: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), // First of month
+			Value:       3,
+			CreatedAt:   sql.NullTime{Time: time.Now(), Valid: true},
+			UpdatedAt:   sql.NullTime{Time: time.Now(), Valid: true},
+			Name:        "Monthly Reading",
+			Description: sql.NullString{String: "Track monthly reading", Valid: true},
+			Target:      5,
+			Unit:        "books",
+			Icon:        "book",
+			Frequency:   "monthly",
+			Direction:   "under",
+		},
+	}
+
+	// Set up mock expectations
+	mockQuerier.On("ListCurrentPeriodGaugeInstances", mock.Anything, mock.AnythingOfType("db.ListCurrentPeriodGaugeInstancesParams")).Return(testInstances, nil)
+
+	// Create test request
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	// Call handler
+	handler.handleDashboard(w, req)
+
+	// Verify response
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/html")
+	
+	// Verify the response contains gauge data
+	body := w.Body.String()
+	assert.Contains(t, body, "Weekly Exercise")
+	assert.Contains(t, body, "Monthly Reading")
+	assert.NotContains(t, body, "No Active Gauges")
+
+	// Verify mock was called
+	mockQuerier.AssertExpectations(t)
+}
+
+func TestHandleDashboard_NoActiveGauges(t *testing.T) {
+	// Create mock querier
+	mockQuerier := new(MockQuerier)
+	handler := NewGaugeHandler(mockQuerier)
+
+	// Set up mock to return empty slice
+	emptyInstances := []db.ListCurrentPeriodGaugeInstancesRow{}
+	mockQuerier.On("ListCurrentPeriodGaugeInstances", mock.Anything, mock.AnythingOfType("db.ListCurrentPeriodGaugeInstancesParams")).Return(emptyInstances, nil)
+
+	// Create test request
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	// Call handler
+	handler.handleDashboard(w, req)
+
+	// Verify response
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/html")
+	
+	// Verify the response shows "no active gauges" message
+	body := w.Body.String()
+	assert.Contains(t, body, "No Active Gauges")
+	assert.Contains(t, body, "No gauge instances are active for the current time period")
+	assert.Contains(t, body, "Create Gauge Templates")
+
+	// Verify mock was called
+	mockQuerier.AssertExpectations(t)
+}
+
+func TestHandleDashboard_DatabaseError(t *testing.T) {
+	// Create mock querier
+	mockQuerier := new(MockQuerier)
+	handler := NewGaugeHandler(mockQuerier)
+
+	// Set up mock to return error
+	mockQuerier.On("ListCurrentPeriodGaugeInstances", mock.Anything, mock.AnythingOfType("db.ListCurrentPeriodGaugeInstancesParams")).Return([]db.ListCurrentPeriodGaugeInstancesRow{}, assert.AnError)
+
+	// Create test request
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	// Call handler
+	handler.handleDashboard(w, req)
+
+	// Verify response
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "Failed to fetch current period gauge instances")
+
+	// Verify mock was called
+	mockQuerier.AssertExpectations(t)
+}
+
+func TestHandleDashboard_FilteringLogic(t *testing.T) {
+	// Create mock querier
+	mockQuerier := new(MockQuerier)
+	handler := NewGaugeHandler(mockQuerier)
+
+	// Create test data with different frequencies
+	testInstances := []db.ListCurrentPeriodGaugeInstancesRow{
+		{
+			ID:          1,
+			TemplateID:  1,
+			PeriodStart: time.Date(2024, 1, 7, 0, 0, 0, 0, time.UTC), // Sunday - weekly
+			Value:       2,
+			Name:        "Weekly Task",
+			Frequency:   "weekly",
+			Target:      5,
+			Unit:        "tasks",
+			Icon:        "check",
+			Direction:   "under",
+		},
+		{
+			ID:          2,
+			TemplateID:  2,
+			PeriodStart: time.Date(2024, 1, 7, 0, 0, 0, 0, time.UTC), // Sunday - bi-weekly
+			Value:       4,
+			Name:        "Bi-weekly Goal",
+			Frequency:   "bi-weekly",
+			Target:      8,
+			Unit:        "goals",
+			Icon:        "target",
+			Direction:   "under",
+		},
+		{
+			ID:          3,
+			TemplateID:  3,
+			PeriodStart: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), // First of month - monthly
+			Value:       1,
+			Name:        "Monthly Habit",
+			Frequency:   "monthly",
+			Target:      3,
+			Unit:        "habits",
+			Icon:        "calendar",
+			Direction:   "under",
+		},
+	}
+
+	// Set up mock expectations
+	mockQuerier.On("ListCurrentPeriodGaugeInstances", mock.Anything, mock.MatchedBy(func(params db.ListCurrentPeriodGaugeInstancesParams) bool {
+		// Verify that the parameters contain proper period start dates
+		// The exact dates will depend on when the test runs, but we can verify the structure
+		return !params.PeriodStart.IsZero() && !params.PeriodStart_2.IsZero() && !params.PeriodStart_3.IsZero()
+	})).Return(testInstances, nil)
+
+	// Create test request
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	// Call handler
+	handler.handleDashboard(w, req)
+
+	// Verify response
+	assert.Equal(t, http.StatusOK, w.Code)
+	
+	// Verify all frequency types are represented
+	body := w.Body.String()
+	assert.Contains(t, body, "Weekly Task")
+	assert.Contains(t, body, "Bi-weekly Goal")
+	assert.Contains(t, body, "Monthly Habit")
+
+	// Verify mock was called
+	mockQuerier.AssertExpectations(t)
+}

--- a/internal/handlers/gauge_handler.go
+++ b/internal/handlers/gauge_handler.go
@@ -5,11 +5,13 @@ import (
 	"database/sql"
 	"fmt"
 	"health-monitor/internal/db"
+	"health-monitor/internal/timeutil"
 	"health-monitor/internal/views/components"
 	"health-monitor/internal/views/layouts"
 	"health-monitor/internal/views/pages"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -25,6 +27,9 @@ type Querier interface {
 	// Gauge Instance methods (for increment/decrement operations)
 	GetGaugeInstance(ctx context.Context, id int64) (db.GaugeInstance, error)
 	UpdateGaugeInstanceValue(ctx context.Context, params db.UpdateGaugeInstanceValueParams) error
+	
+	// Dashboard methods
+	ListCurrentPeriodGaugeInstances(ctx context.Context, params db.ListCurrentPeriodGaugeInstancesParams) ([]db.ListCurrentPeriodGaugeInstancesRow, error)
 }
 
 type GaugeHandler struct {
@@ -37,8 +42,39 @@ func NewGaugeHandler(queries Querier) *GaugeHandler {
 	}
 }
 
+// handleDashboard renders the main dashboard page with current period gauge instances
+func (h *GaugeHandler) handleDashboard(w http.ResponseWriter, r *http.Request) {
+	// Calculate current period starts for all frequencies
+	currentTime := time.Now()
+	weeklyStart := timeutil.CalculateCurrentPeriodStart("weekly", currentTime)
+	biWeeklyStart := timeutil.CalculateCurrentPeriodStart("bi-weekly", currentTime)
+	monthlyStart := timeutil.CalculateCurrentPeriodStart("monthly", currentTime)
+
+	// Query current period gauge instances
+	gaugeInstances, err := h.queries.ListCurrentPeriodGaugeInstances(r.Context(), db.ListCurrentPeriodGaugeInstancesParams{
+		PeriodStart:   weeklyStart,
+		PeriodStart_2: biWeeklyStart,
+		PeriodStart_3: monthlyStart,
+	})
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to fetch current period gauge instances: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Render dashboard
+	w.Header().Set("Content-Type", "text/html")
+	err = layouts.Base("Dashboard", pages.Dashboard(gaugeInstances)).Render(r.Context(), w)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to render dashboard: %v", err), http.StatusInternalServerError)
+		return
+	}
+}
+
 // RegisterRoutes registers all gauge-related routes on the provided router
 func (h *GaugeHandler) RegisterRoutes(r chi.Router) {
+	// Dashboard
+	r.Get("/", h.handleDashboard)
+	
 	// Admin dashboard
 	r.Get("/admin", h.handleAdmin)
 

--- a/internal/views/components/current_period_indicator.templ
+++ b/internal/views/components/current_period_indicator.templ
@@ -1,0 +1,54 @@
+package components
+
+import (
+	"fmt"
+	"health-monitor/internal/timeutil"
+	"time"
+)
+
+templ CurrentPeriodIndicator() {
+	<div class="bg-base-200 rounded-lg p-4 mb-4">
+		<div class="flex items-center justify-center gap-4">
+			<div class="text-center">
+				<div class="text-sm text-base-content/70 mb-1">Current Period</div>
+				<div class="text-lg font-semibold">{ formatCurrentDate() }</div>
+			</div>
+			<div class="divider divider-horizontal"></div>
+			<div class="flex gap-6">
+				<div class="text-center">
+					<div class="text-xs text-base-content/60">Weekly</div>
+					<div class="text-sm font-medium">{ formatPeriodRange("weekly") }</div>
+				</div>
+				<div class="text-center">
+					<div class="text-xs text-base-content/60">Bi-weekly</div>
+					<div class="text-sm font-medium">{ formatPeriodRange("bi-weekly") }</div>
+				</div>
+				<div class="text-center">
+					<div class="text-xs text-base-content/60">Monthly</div>
+					<div class="text-sm font-medium">{ formatPeriodRange("monthly") }</div>
+				</div>
+			</div>
+		</div>
+	</div>
+}
+
+func formatCurrentDate() string {
+	return time.Now().Format("Monday, January 2, 2006")
+}
+
+func formatPeriodRange(frequency string) string {
+	currentTime := time.Now()
+	start := timeutil.CalculateCurrentPeriodStart(frequency, currentTime)
+	end := timeutil.CalculatePeriodEnd(frequency, start)
+	
+	switch frequency {
+	case "weekly":
+		return fmt.Sprintf("%s - %s", start.Format("Jan 2"), end.Format("Jan 2"))
+	case "bi-weekly":
+		return fmt.Sprintf("%s - %s", start.Format("Jan 2"), end.Format("Jan 2"))
+	case "monthly":
+		return start.Format("January 2006")
+	default:
+		return start.Format("Jan 2")
+	}
+}

--- a/internal/views/pages/dashboard.templ
+++ b/internal/views/pages/dashboard.templ
@@ -6,26 +6,48 @@ import (
 )
 
 templ Dashboard(gaugeInstances []db.ListCurrentPeriodGaugeInstancesRow) {
-	<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-		for _, instance := range gaugeInstances {
-			@components.GaugeCard(&db.GaugeInstance{
-				ID: instance.ID,
-				TemplateID: instance.TemplateID,
-				PeriodStart: instance.PeriodStart,
-				Value: instance.Value,
-				CreatedAt: instance.CreatedAt,
-				UpdatedAt: instance.UpdatedAt,
-			}, &db.GaugeTemplate{
-				ID: instance.TemplateID,
-				Name: instance.Name,
-				Description: instance.Description,
-				Target: instance.Target,
-				Unit: instance.Unit,
-				Icon: instance.Icon,
-				Frequency: instance.Frequency,
-				Direction: instance.Direction,
-				Active: true, // Only active templates are returned
-			})
+	<div class="dashboard-container">
+		<!-- Current Period Indicator -->
+		<div class="dashboard-header mb-6">
+			@components.CurrentPeriodIndicator()
+		</div>
+		
+		<!-- Gauge Instances Grid -->
+		if len(gaugeInstances) == 0 {
+			<div class="text-center py-12">
+				<div class="text-6xl mb-4">📊</div>
+				<h2 class="text-2xl font-bold text-base-content/70 mb-2">No Active Gauges</h2>
+				<p class="text-base-content/60 mb-4">No gauge instances are active for the current time period.</p>
+				<a href="/admin" class="btn btn-primary">
+					<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+					</svg>
+					Create Gauge Templates
+				</a>
+			</div>
+		} else {
+			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+				for _, instance := range gaugeInstances {
+					@components.GaugeCard(&db.GaugeInstance{
+						ID: instance.ID,
+						TemplateID: instance.TemplateID,
+						PeriodStart: instance.PeriodStart,
+						Value: instance.Value,
+						CreatedAt: instance.CreatedAt,
+						UpdatedAt: instance.UpdatedAt,
+					}, &db.GaugeTemplate{
+						ID: instance.TemplateID,
+						Name: instance.Name,
+						Description: instance.Description,
+						Target: instance.Target,
+						Unit: instance.Unit,
+						Icon: instance.Icon,
+						Frequency: instance.Frequency,
+						Direction: instance.Direction,
+						Active: true, // Only active templates are returned
+					})
+				}
+			</div>
 		}
 	</div>
 }


### PR DESCRIPTION
- Add dedicated dashboard handler with current period filtering logic
- Create CurrentPeriodIndicator component showing active time periods
- Update dashboard template with 'no active gauges' message
- Add comprehensive unit tests for dashboard filtering functionality
- Move dashboard logic from main.go to proper handler structure
- Support filtering for weekly, bi-weekly, and monthly frequencies
- Include proper error handling and user-friendly messaging

Resolves task 7: Implement dashboard filtering for current period gauges